### PR TITLE
Keep track of slot weights

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: "java"
 
-version "0.4"
+version "0.5"
 
 sourceCompatibility = "1.7"
 targetCompatibility = "1.7"

--- a/src/main/java/com/andyhawkes/chronic/AveragingTimeSeries.java
+++ b/src/main/java/com/andyhawkes/chronic/AveragingTimeSeries.java
@@ -3,27 +3,43 @@ package com.andyhawkes.chronic;
 /**
  * A time series that keeps averages of the values in each slot.
  */
-public class AveragingTimeSeries extends PurgeableTimeSeries {
-	public AveragingTimeSeries(long interval) {
-		super(interval);
-	}
+public class AveragingTimeSeries extends PurgeableTimeSeries implements WeightedTimeSeries {
+    public AveragingTimeSeries(long interval) {
+        super(interval);
+    }
+
+    public int getWeight(long interval) {
+        TimeSlot slot = getSlotAtTime(interval);
+
+        if (slot != null) {
+            return ((WeightedSlot) slot).getWeight();
+        } else {
+            return 0;
+        }
+    }
 
     protected TimeSlot createTimeSlot() {
-        return new TimeSlot() {
-            private int weight = 0;
-            private double value = 0.00;
+        return new WeightedSlot();
+    }
 
-            public void addValue(double value) {
-                double average = ((this.value * this.weight) + value) / (this.weight + 1);
+    private class WeightedSlot implements TimeSlot {
+        private int weight = 0;
+        private double value = 0.00;
 
-                this.value = average;
-                this.weight++;
-            }
+        public void addValue(double value) {
+            double average = ((this.value * this.weight) + value) / (this.weight + 1);
 
-            public double getValue() {
-                return value;
-            }
-        };
+            this.value = average;
+            this.weight++;
+        }
+
+        public double getValue() {
+            return value;
+        }
+
+        public int getWeight() {
+            return weight;
+        }
     }
 }
 

--- a/src/main/java/com/andyhawkes/chronic/TimeSeries.java
+++ b/src/main/java/com/andyhawkes/chronic/TimeSeries.java
@@ -8,46 +8,46 @@ public interface TimeSeries {
 	/**
 	 * Adds a value to the time series.
 	 */
-	public void addValue(long time, double value);
+	void addValue(long time, double value);
 
 	/**
 	 * Gets a value at a specific time.
 	 */
-	public double getValue(long time);
+	double getValue(long time);
 
 	/**
 	 * Returns the interval (the duration of each bucket).
 	 */
-	public long getInterval();
+	long getInterval();
 
 	/**
 	 * Returns the amount of maximum change over a given period. For example,
 	 * the sharpest increase over any 9000ms time period.
 	 */
-	public double getMaxDelta(long period);
+	double getMaxDelta(long period);
 
 	/**
 	 * Returns the amount of minimum change over a given period. For example,
 	 * the least increase (or biggest decrease) over any 9000ms time period.
 	 */
-	public double getMinDelta(long period);
+	double getMinDelta(long period);
 
 	/**
 	 * Calculates the slope leading up to a certain time. The slope is
 	 * calculated by going back 2 buckets, or up to 5 buckets if data is missing
 	 * due to a network blip or something.
 	 */
-	public double getSmartSlope(long endTime);
+	double getSmartSlope(long endTime);
 
-	public double getDelta(long startTime, long endTime);
+	double getDelta(long startTime, long endTime);
 
-	public double getMaxValue();
+	double getMaxValue();
 
-	public double getAvgValue();
+	double getAvgValue();
 
-	public double getMinValue();
+	double getMinValue();
 
-	public long getEarliestTime();
+	long getEarliestTime();
 
-	public long getLatestTime();
+	long getLatestTime();
 }

--- a/src/main/java/com/andyhawkes/chronic/TimeSlot.java
+++ b/src/main/java/com/andyhawkes/chronic/TimeSlot.java
@@ -4,7 +4,7 @@ package com.andyhawkes.chronic;
  * A slot within a time series. Each slot contains data for a specific time range, such as 3000-5999 milliseconds.
  */
 public interface TimeSlot {
-    public void addValue(double value);
+    void addValue(double value);
 
-    public double getValue();
+    double getValue();
 }

--- a/src/main/java/com/andyhawkes/chronic/WeightedTimeSeries.java
+++ b/src/main/java/com/andyhawkes/chronic/WeightedTimeSeries.java
@@ -1,0 +1,9 @@
+package com.andyhawkes.chronic;
+
+/**
+ * A time series that keeps track of the "weight" of each time slot (the number of samples that contributed to the
+ * aggregate). This is useful for computing averages of averages.
+ */
+public interface WeightedTimeSeries extends TimeSeries {
+    int getWeight(long time);
+}

--- a/src/test/java/com/andyhawkes/chronic/CachingTest.java
+++ b/src/test/java/com/andyhawkes/chronic/CachingTest.java
@@ -27,7 +27,7 @@ public class CachingTest {
 
         Assert.assertEquals("50th percentile at 140000 should be 7", 7, cachingTimeSeries.getValue(140000), 0.0001);
         Assert.assertEquals("50th percentile at 40000 should still be 5", 5, cachingTimeSeries.getValue(40000), 0.0001);
-        Assert.assertEquals("50th percentile at 180000 should be 0", 0, cachingTimeSeries.getValue(180000), 0.0001);
+        Assert.assertEquals("50th percentile at 180000 should be NaN", Double.NaN, cachingTimeSeries.getValue(180000), 0.0001);
 
         Assert.assertTrue("Values should be the same at 140000", cachingTimeSeries.getValue(140000) == percentileTimeSeries.getValue(140000));
         Assert.assertTrue("Values should not be the same at 40000 because the underlying series was purged", cachingTimeSeries.getValue(40000) != percentileTimeSeries.getValue(40000));

--- a/src/test/java/com/andyhawkes/chronic/PurgeTest.java
+++ b/src/test/java/com/andyhawkes/chronic/PurgeTest.java
@@ -15,7 +15,7 @@ public class PurgeTest {
 
         series.purgeSlotAtIndex(6);
 
-        Assert.assertEquals("Average at 20000 should be 0", 0, series.getValue(20000), 0.00001);
+        Assert.assertEquals("Average at 20000 should be NaN", Double.NaN, series.getValue(20000), 0.00001);
 
         series.addValue(20000, 9);
 

--- a/src/test/java/com/andyhawkes/chronic/TimeSeriesTest.java
+++ b/src/test/java/com/andyhawkes/chronic/TimeSeriesTest.java
@@ -48,7 +48,7 @@ public class TimeSeriesTest {
 
 	@Test
 	public void testAveragingTimeSeries() {
-		TimeSeries series = new AveragingTimeSeries(4000);
+		AveragingTimeSeries series = new AveragingTimeSeries(4000);
 
 		series.addValue(13, 3.7);
 		series.addValue(1280, 7.4);
@@ -68,6 +68,11 @@ public class TimeSeriesTest {
 		Assert.assertEquals(series.getValue(7999), 3.1, 0.0001);
 		Assert.assertEquals(series.getValue(10000), 6.8, 0.0001);
 		Assert.assertTrue(Double.isNaN(series.getValue(13000)));
+
+		Assert.assertEquals(6, series.getWeight(1000));
+		Assert.assertEquals(3, series.getWeight(6000));
+		Assert.assertEquals(1, series.getWeight(9000));
+		Assert.assertEquals(0, series.getWeight(13000));
 
 		Assert.assertEquals(3.1, series.getMinValue(), 0.0001);
 		Assert.assertEquals((4.05 + 3.1 + 6.8) / 3, series.getAvgValue(), 0.0001);
@@ -78,7 +83,7 @@ public class TimeSeriesTest {
 
 	@Test
 	public void testWeightedAveragingTimeSeries() {
-		TimeSeries series = new WeightedAveragingTimeSeries(4000);
+		WeightedAveragingTimeSeries series = new WeightedAveragingTimeSeries(4000);
 
 		series.addValue(13, 3.7);
 		series.addValue(1280, 7.4);
@@ -99,11 +104,29 @@ public class TimeSeriesTest {
 		Assert.assertEquals(series.getValue(10000), 6.8, 0.0001);
 		Assert.assertTrue(Double.isNaN(series.getValue(13000)));
 
+		Assert.assertEquals(6, series.getWeight(1000));
+		Assert.assertEquals(3, series.getWeight(5000));
+		Assert.assertEquals(1, series.getWeight(9000));
+		Assert.assertEquals(0, series.getWeight(13000));
+
 		Assert.assertEquals(0.6, series.getMinValue(), 0.0001);
 		Assert.assertEquals(4.04, series.getAvgValue(), 0.0001);
 		Assert.assertEquals(7.4, series.getMaxValue(), 0.0001);
 
 		Assert.assertEquals(11999, series.getLatestTime());
+	}
+
+	@Test
+	public void testWeightedAveragingTimeSeriesLotsOfData() {
+		TimeSeries series = new WeightedAveragingTimeSeries(4000);
+
+		for (long t = 0; t < 6 * 3600000; t += 15000) {
+			series.addValue(t, 0.372);
+		}
+
+		Assert.assertEquals(0.372, series.getMinValue(), 0.0001);
+		Assert.assertEquals(0.372, series.getAvgValue(), 0.0001);
+		Assert.assertEquals(0.372, series.getMaxValue(), 0.0001);
 	}
 
 	@Test


### PR DESCRIPTION
Adding a new feature to AveragingTimeSeries and its descendants, so we can find out how many samples contributed to the average for a given time slot.

This is so we can reliably make an average of averages between multiple time series... for example, what was the overall average value at 30,000 milliseconds between 5 different series, each of which could be aggregating a different number of samples in that time slot?